### PR TITLE
Added support for Firefox's cloneInto when it complains about it

### DIFF
--- a/change-log.md
+++ b/change-log.md
@@ -1,4 +1,4 @@
 * 1.0.1 (2016-09-12)
   * _patch_: Added support for Firefox's cloneInto
-* 1.0.0 (TBD)
+* 1.0.0 (2015-12-14)
   * _Major_: Adds support for node buffers

--- a/change-log.md
+++ b/change-log.md
@@ -1,4 +1,4 @@
-
-
+* 1.0.1 (2016-09-12)
+  * _patch_: Added support for Firefox's cloneInto
 * 1.0.0 (TBD)
   * _Major_: Adds support for node buffers

--- a/lib/binary.js
+++ b/lib/binary.js
@@ -83,6 +83,7 @@ function typeToOtherType(type, otherType, data) {
       return conversionMethods[type][otherType](data);
   }
   catch (e) {
+    //@HACK: This is to solve the accessing TypedArray data over Xrays issue in Firefox
     if (e.message.indexOf('cloneInto()') >= 0 && typeof cloneInto === 'function' && typeof window !=='undefined') {
       return conversionMethods[type][otherType](cloneInto(data, window));
     }

--- a/lib/binary.js
+++ b/lib/binary.js
@@ -78,13 +78,26 @@ Binary.prototype.asArrayBuffer = function() {
   return conversionMethods[this._type][Binary.ARRAY_BUFFER](this._data);
 };
 
+function typeToOtherType(type, otherType, data) {
+  try {
+      return conversionMethods[type][otherType](data);
+  }
+  catch (e) {
+    if (e.message.indexOf('cloneInto()') >= 0 && typeof cloneInto === 'function' && typeof window !=='undefined') {
+      return conversionMethods[type][otherType](cloneInto(data, window));
+    }
+
+    throw e;
+  }
+}
+
 /**
  * Turn the binary data into a string
  *
  * @returns {String} Data represented as a string
  */
 Binary.prototype.asString = function() {
-  return conversionMethods[this._type][Binary.STRING](this._data);
+  return typeToOtherType(this._type, Binary.STRING, this._data);
 };
 
 /**
@@ -93,7 +106,7 @@ Binary.prototype.asString = function() {
  * @returns {Array} Data represented as an array of bytes
  */
 Binary.prototype.asByteArray = function() {
-  return conversionMethods[this._type][Binary.BYTE_ARRAY](this._data);
+  return typeToOtherType(this._type, Binary.BYTE_ARRAY, this._data);
 };
 
 /**
@@ -121,8 +134,6 @@ Binary.prototype.isArrayBuffer = function() {
 Binary.prototype.isBuffer = function() {
   return this._type === Binary.BUFFER;
 };
-
-
 
 /**
  @param {Number} [start]

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "binary",
   "repo": "virtru/binary",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "license": "UNLICENSED",
   "scripts": {


### PR DESCRIPTION
Vault Extension does not work without this change. Inside of `SecureService.prototype.readMessage` the line `Binary.fromString(sanitizeUtils.sanitizeAndUtf8DecodeString(tdf.payload.asString())));` blows up asking for the use of `cloneInto` for `tdf.payload.asString`. This adds in support for the two conversions that could blow it up for ArrayBuffer. 