### PR TITLE
fixes issue with firefox converting of arraybuffers

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+### Proposed Changes
+
+*Replace this text with an overview of what changed and why.*
+
+### Checklist
+
+*Place an `x` inside the brackets to check off items.*
+
+- [ ] I have added or updated unit tests
+- [ ] I have added or updated integration tests (if appropriate)
+- [ ] I have added or updated documentation (if appropriate)
+- [ ] I have verified that my changes have not introduced new lint errors
+- [ ] I have [updated the change log](https://github.com/virtru/dev-guide/blob/master/process/merge-and-tag.md#change-log)
+
+### Testing Instructions
+
+*Provide detailed instructions that can be used on their own to validate the changes.*
+
+1. 
+2. 
+3. 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,21 +1,14 @@
+changes: _rev_
+
 ### Proposed Changes
 
-*Replace this text with an overview of what changed and why.*
+* 
 
 ### Checklist
 
-*Place an `x` inside the brackets to check off items.*
-
-- [ ] I have added or updated unit tests
 - [ ] I have added or updated integration tests (if appropriate)
 - [ ] I have added or updated documentation (if appropriate)
 - [ ] I have verified that my changes have not introduced new lint errors
-- [ ] I have [updated the change log](https://github.com/virtru/dev-guide/blob/master/process/merge-and-tag.md#change-log)
+- [ ] I have updated the change log
 
 ### Testing Instructions
-
-*Provide detailed instructions that can be used on their own to validate the changes.*
-
-1. 
-2. 
-3. 

--- a/change-log.md
+++ b/change-log.md
@@ -1,3 +1,5 @@
+* 1.0.2 (2017-01-23)
+  * _patch_: Fixes issue with firefox failing to convert opaque buffers
 * 1.0.1 (2016-09-12)
   * _patch_: Added support for Firefox's cloneInto
 * 1.0.0 (2015-12-14)

--- a/lib/binary.js
+++ b/lib/binary.js
@@ -118,6 +118,9 @@ Binary.prototype.asByteArray = function() {
  Binary.prototype.asBuffer = function() {
   var converted;
   var conversionMethod = conversionMethods[this._type][Binary.BUFFER];
+  // If it fails, try converting data to Uint8Array and try again..
+  // This is addressing an issue in Firefox, where it fails to convert
+  // if _data is from an opaque object.
   try {
     converted = conversionMethod(this._data);
   } catch (e) {

--- a/lib/binary.js
+++ b/lib/binary.js
@@ -119,9 +119,9 @@ Binary.prototype.asByteArray = function() {
   var converted;
   var conversionMethod = conversionMethods[this._type][Binary.BUFFER];
   try {
-	  converted = conversionMethod(this._data);
+    converted = conversionMethod(this._data);
   } catch (e) {
-	  converted = conversionMethod(new Uint8Array(this._data));
+    converted = conversionMethod(new Uint8Array(this._data));
   }
   return converted;
  };

--- a/lib/binary.js
+++ b/lib/binary.js
@@ -116,14 +116,14 @@ Binary.prototype.asByteArray = function() {
  * @returns {Array} Data represented as an array of bytes
  */
  Binary.prototype.asBuffer = function() {
-	 var converted;
-	 var conversionMethod = conversionMethods[this._type][Binary.BUFFER];
-	 try {
-		 converted = conversionMethod(this._data);
-	 } catch (e) {
-		 converted = conversionMethod(new Uint8Array(this._data));
-	 }
-	 return converted;
+  var converted;
+  var conversionMethod = conversionMethods[this._type][Binary.BUFFER];
+  try {
+	  converted = conversionMethod(this._data);
+  } catch (e) {
+	  converted = conversionMethod(new Uint8Array(this._data));
+  }
+  return converted;
  };
 
 Binary.prototype.isBuffer = function() {

--- a/lib/binary.js
+++ b/lib/binary.js
@@ -115,10 +115,16 @@ Binary.prototype.asByteArray = function() {
  *
  * @returns {Array} Data represented as an array of bytes
  */
-Binary.prototype.asBuffer = function() {
-  return conversionMethods[this._type][Binary.BUFFER](this._data);
-};
-
+ Binary.prototype.asBuffer = function() {
+	 var converted;
+	 var conversionMethod = conversionMethods[this._type][Binary.BUFFER];
+	 try {
+		 converted = conversionMethod(this._data);
+	 } catch (e) {
+		 converted = conversionMethod(new Uint8Array(this._data));
+	 }
+	 return converted;
+ };
 
 Binary.prototype.isBuffer = function() {
   return this._type === Binary.BUFFER;


### PR DESCRIPTION
### Proposed Changes

Updates to fix issue where firefox can't convert opaque arraybuffers.

### Checklist

*Place an `x` inside the brackets to check off items.*

- [x] I have added or updated unit tests
- [x] I have added or updated integration tests (if appropriate)
- [x] I have added or updated documentation (if appropriate)
- [x] I have verified that my changes have not introduced new lint errors
- [x] I have [updated the change log](https://github.com/virtru/dev-guide/blob/master/process/merge-and-tag.md#change-log)

### Testing Instructions

*Provide detailed instructions that can be used on their own to validate the changes.*

1. Build BP/SR, with this binary lib, and ensure shit doesn't break.